### PR TITLE
Upgrade Java version and improve model search

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/screens/ModelsScreen.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/screens/ModelsScreen.kt
@@ -58,6 +58,9 @@ fun ModelsScreen(
 ) {
     val viewModel = koinViewModel<ModelsViewModel>()
     val screenState = viewModel.screenState.collectAsState()
+    val searchQuery = rememberSaveable {
+        mutableStateOf(String())
+    }
 
     BackHandler {
         onLeaveScreen.invoke()
@@ -107,9 +110,10 @@ fun ModelsScreen(
                     Spacer(modifier = Modifier.height(LocalDim.current.spaceExtraSmall))
 
                     ClearableTextField(
-                        value = viewModel.searchQuery,
+                        value = searchQuery.value,
                         hint = stringResource(R.string.lbl_model_search_hint),
                         onValueChange = {
+                            searchQuery.value = it
                             viewModel.onSearchQueryChanged(it)
                         }
                     )

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/viewModels/ModelsViewModel.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/viewModels/ModelsViewModel.kt
@@ -14,8 +14,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-private const val EMPTY_STRING = ""
-
 class ModelsViewModel(
     savedStateHandle: SavedStateHandle,
     private val modelsRepository: ModelsRepository
@@ -25,10 +23,6 @@ class ModelsViewModel(
     val selectedManufacturerName = manufacturer.chosenManufacturerName
 
     private var searchJob: Job? = null
-
-    var searchQuery: String = EMPTY_STRING
-        private set
-
     private val _screenState = MutableStateFlow<ModelsScreenState>(ModelsScreenState.Loading)
     val screenState = _screenState.asStateFlow()
 
@@ -41,13 +35,12 @@ class ModelsViewModel(
     }
 
     fun onSearchQueryChanged(query: String) {
-        searchQuery = query
         searchJob?.cancel()
 
         searchJob = viewModelScope.launch(Dispatchers.IO) {
             _screenState.emit(
                 ModelsScreenState.Content(
-                    modelsRepository.searchModelByName(searchQuery)
+                    modelsRepository.searchModelByName(query)
                 )
             )
         }


### PR DESCRIPTION
- Upgraded the Java source and target compatibility to version 21 in `data` and `domain` modules.
- Removed the `searchQuery` variable from `ModelsViewModel`.
- Modified `ModelsViewModel` to use the current search query value in the `onSearchQueryChanged` method instead.
- Updated `ModelsScreen` to use a `mutableStateOf` to remember the search query.